### PR TITLE
Add Autodesk courses to courses.html

### DIFF
--- a/courses.html
+++ b/courses.html
@@ -145,6 +145,168 @@
       </div>
     </section><!-- End Courses Section -->
 
+    <!-- ======= New Courses Section ======= -->
+    <section id="new-courses" class="courses">
+      <div class="container" data-aos="fade-up">
+        <div class="section-title">
+          <h2>New Courses</h2>
+        </div>
+        <div class="row" data-aos="zoom-in" data-aos-delay="100">
+
+          <div class="col-lg-4 col-md-6 d-flex align-items-stretch">
+            <div class="course-item">
+              <div class="course-content">
+                <div class="d-flex justify-content-between align-items-center mb-3">
+                  <h4>Foundations of AutoCAD</h4>
+                </div>
+                <h3><a href="#">Foundations of AutoCAD</a></h3>
+                <p>Duration: 8 weeks</p>
+                <p>Level: Beginner</p>
+                <p>Course Objectives:</p>
+                <ul>
+                  <li>Master the AutoCAD interface and basic commands</li>
+                  <li>Develop proficiency in 2D drafting and documentation</li>
+                  <li>Learn industry-standard CAD practices</li>
+                </ul>
+                <p>Weekly Breakdown:</p>
+                <ul>
+                  <li>Week 1: Introduction to AutoCAD</li>
+                  <li>Week 2: Basic Drawing Tools</li>
+                  <li>Week 3: Precision Drawing & Editing</li>
+                  <li>Week 4: Advanced Editing Tools</li>
+                  <li>Week 5: Annotation & Documentation</li>
+                  <li>Week 6: Layouts & Printing</li>
+                  <li>Week 7: Blocks & References</li>
+                  <li>Week 8: Project Work</li>
+                </ul>
+                <div class="trainer d-flex justify-content-between align-items-center">
+                  <div class="trainer-profile d-flex align-items-center">
+                  </div>
+                  <div class="trainer-rank d-flex align-items-center">
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div> <!-- End Course Item-->
+
+          <div class="col-lg-4 col-md-6 d-flex align-items-stretch mt-4 mt-md-0">
+            <div class="course-item">
+              <div class="course-content">
+                <div class="d-flex justify-content-between align-items-center mb-3">
+                  <h4>3D Modeling with Autodesk Fusion 360</h4>
+                </div>
+                <h3><a href="#">3D Modeling with Autodesk Fusion 360</a></h3>
+                <p>Duration: 10 weeks</p>
+                <p>Level: Intermediate</p>
+                <p>Course Objectives:</p>
+                <ul>
+                  <li>Understand 3D modeling concepts</li>
+                  <li>Master parametric design principles</li>
+                  <li>Create complex assemblies</li>
+                </ul>
+                <p>Weekly Breakdown:</p>
+                <ul>
+                  <li>Week 1: Introduction to Fusion 360</li>
+                  <li>Week 2: Parametric Sketching</li>
+                  <li>Week 3: Basic 3D Operations</li>
+                  <li>Week 4: Advanced Modeling Techniques</li>
+                  <li>Week 5: Assembly Modeling</li>
+                  <li>Week 6: Design Analysis</li>
+                  <li>Week 7: Rendering & Visualization</li>
+                  <li>Week 8: CAM Basics</li>
+                  <li>Week 9: Collaboration Tools</li>
+                  <li>Week 10: Final Project</li>
+                </ul>
+                <div class="trainer d-flex justify-content-between align-items-center">
+                  <div class="trainer-profile d-flex align-items-center">
+                  </div>
+                  <div class="trainer-rank d-flex align-items-center">
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div> <!-- End Course Item-->
+
+          <div class="col-lg-4 col-md-6 d-flex align-items-stretch mt-4 mt-lg-0">
+            <div class="course-item">
+              <div class="course-content">
+                <div class="d-flex justify-content-between align-items-center mb-3">
+                  <h4>Building Information Modeling with Revit</h4>
+                </div>
+                <h3><a href="#">Building Information Modeling with Revit</a></h3>
+                <p>Duration: 12 weeks</p>
+                <p>Level: Intermediate to Advanced</p>
+                <p>Course Objectives:</p>
+                <ul>
+                  <li>Master BIM concepts and workflows</li>
+                  <li>Create detailed architectural models</li>
+                  <li>Develop construction documentation</li>
+                </ul>
+                <p>Weekly Breakdown:</p>
+                <ul>
+                  <li>Week 1: BIM Fundamentals</li>
+                  <li>Week 2: Building Elements</li>
+                  <li>Week 3: Component Families</li>
+                  <li>Week 4: MEP Systems</li>
+                  <li>Week 5: Structural Elements</li>
+                  <li>Week 6: Documentation</li>
+                  <li>Week 7: Site & Context</li>
+                  <li>Week 8: Visualization</li>
+                  <li>Week 9: Collaboration</li>
+                  <li>Week 10: Energy Analysis</li>
+                  <li>Week 11: Construction Documentation</li>
+                  <li>Week 12: Final Project</li>
+                </ul>
+                <div class="trainer d-flex justify-content-between align-items-center">
+                  <div class="trainer-profile d-flex align-items-center">
+                  </div>
+                  <div class="trainer-rank d-flex align-items-center">
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div> <!-- End Course Item-->
+
+          <div class="col-lg-4 col-md-6 d-flex align-items-stretch mt-4">
+            <div class="course-item">
+              <div class="course-content">
+                <div class="d-flex justify-content-between align-items-center mb-3">
+                  <h4>Advanced Visualization with 3ds Max</h4>
+                </div>
+                <h3><a href="#">Advanced Visualization with 3ds Max</a></h3>
+                <p>Duration: 8 weeks</p>
+                <p>Level: Advanced</p>
+                <p>Course Objectives:</p>
+                <ul>
+                  <li>Create photorealistic renderings</li>
+                  <li>Master advanced lighting techniques</li>
+                  <li>Develop architectural visualizations</li>
+                </ul>
+                <p>Weekly Breakdown:</p>
+                <ul>
+                  <li>Week 1: 3ds Max Fundamentals</li>
+                  <li>Week 2: Advanced Modeling</li>
+                  <li>Week 3: Materials & Texturing</li>
+                  <li>Week 4: Lighting Techniques</li>
+                  <li>Week 5: Camera & Composition</li>
+                  <li>Week 6: Advanced Rendering</li>
+                  <li>Week 7: Post-Production</li>
+                  <li>Week 8: Portfolio Project</li>
+                </ul>
+                <div class="trainer d-flex justify-content-between align-items-center">
+                  <div class="trainer-profile d-flex align-items-center">
+                  </div>
+                  <div class="trainer-rank d-flex align-items-center">
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div> <!-- End Course Item-->
+
+        </div>
+      </div>
+    </section><!-- End New Courses Section -->
+
   </main><!-- End #main -->
 
   <!-- ======= Footer ======= -->


### PR DESCRIPTION
Add new courses section to `courses.html` using existing styling template.

* **New Courses Section**
  - Add a new section titled "New Courses" under the existing courses section.
  - Include four new courses: "Foundations of AutoCAD", "3D Modeling with Autodesk Fusion 360", "Building Information Modeling with Revit", and "Advanced Visualization with 3ds Max".
  - Use the same HTML structure and styling as the existing courses.
  - Display course details including duration, level, objectives, and weekly breakdown for each new course.

